### PR TITLE
Add field last measure for F5D and P5D

### DIFF
--- a/empowering_api/__terp__.py
+++ b/empowering_api/__terp__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Empowering API",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "depends": ["base", "giscedata_polissa", "giscedata_lectures"],
     "author": "GISCE-TI, S.L.",
     "category": "Misc",

--- a/empowering_api/giscedata_lectures.py
+++ b/empowering_api/giscedata_lectures.py
@@ -4,18 +4,21 @@ class GiscedataLecturesComptador(osv.osv):
     _name = 'giscedata.lectures.comptador'
     _inherit = 'giscedata.lectures.comptador'
 
-    def update_empowering_last_measure(self, cursor, uid, ids, last_measure):
+    def update_empowering_last_measure(self, cursor, uid, ids, last_measure, type_measure='empowering_last_measure'):
+	#Default type_measure=empowering_last_measure (for back compatibility) can be empowering_last_f5d_measure and empowering_last_p5d_measure
         upd_ids = []
-        for comp in self.read(cursor, uid, ids, ['empowering_last_measure']):
-            if last_measure > comp['empowering_last_measure']:
+        for comp in self.read(cursor, uid, ids, [type_measure]):
+            if last_measure > comp[type_measure]:
                 upd_ids.append(comp['id'])
         self.write(cursor, uid, upd_ids, {
-            'empowering_last_measure': last_measure
+            type_measure: last_measure
         })
         return len(upd_ids)
 
     _columns = {
         'empowering_last_measure': fields.datetime('Last meassure sent')
+        'empowering_last_f5d_measure': fields.datetime('Last meassure sent')
+        'empowering_last_p5d_measure': fields.datetime('Last meassure sent')
     }
 
 GiscedataLecturesComptador()

--- a/empowering_api/giscedata_lectures.py
+++ b/empowering_api/giscedata_lectures.py
@@ -16,9 +16,9 @@ class GiscedataLecturesComptador(osv.osv):
         return len(upd_ids)
 
     _columns = {
-        'empowering_last_measure': fields.datetime('Last meassure sent')
-        'empowering_last_f5d_measure': fields.datetime('Last meassure sent')
-        'empowering_last_p5d_measure': fields.datetime('Last meassure sent')
+        'empowering_last_measure': fields.datetime('Last F1 meassure sent'),
+        'empowering_last_f5d_measure': fields.datetime('Last F5D meassure sent'),
+        'empowering_last_p5d_measure': fields.datetime('Last P5D meassure sent')
     }
 
 GiscedataLecturesComptador()


### PR DESCRIPTION
We use field empower_last_measure for F1 measeure. We need different field for F5D and P5D to track last measure update of this type of measures.

From Trello task: https://trello.com/c/NrskmzTi/1185-3-6-infoenergia-pujar-corves-f5d-a-beedata-mitjan%C3%A7ant-lapi